### PR TITLE
Fixed github links for source code cloning

### DIFF
--- a/build_instructions.txt
+++ b/build_instructions.txt
@@ -54,11 +54,11 @@ package a USB recovery device.
 - Get the source code:
 
   cd ${TOP}
-  git clone https://github.com:alexelder/aspen-tools.git
-  git clone https://github.com:alexelder/aspen-linux.git
-  git clone https://github.com:alexelder/aspen-u-boot.git
-  git clone https://github.com:alexelder/aspen-arm-trusted-firmware.git
-  git clone https://github.com:alexelder/aspen-l-loader.git
+  git clone https://github.com/alexelder/aspen-tools.git
+  git clone https://github.com/alexelder/aspen-linux.git
+  git clone https://github.com/alexelder/aspen-u-boot.git
+  git clone https://github.com/alexelder/aspen-arm-trusted-firmware.git
+  git clone https://github.com/alexelder/aspen-l-loader.git
 
 - Set up branches to use, and make sure everything is clean:
 


### PR DESCRIPTION
Github links for source code cloning was not working
due to a : instead of a /

Signed-off-by: Robert Wolff <robert.wolff@linaro.org>